### PR TITLE
Call Appodeal.confirm(Appodeal.SKIPPABLE_VIDEO)

### DIFF
--- a/appodeal/android/src/GodotAppodeal.java
+++ b/appodeal/android/src/GodotAppodeal.java
@@ -60,10 +60,12 @@ public class GodotAppodeal extends Godot.SingletonBase
                 }
                 else if(type.equals("banner/video"))
                 {
+       		    Appodeal.confirm(Appodeal.SKIPPABLE_VIDEO);
                     Appodeal.initialize(activity, appKey, Appodeal.BANNER | Appodeal.SKIPPABLE_VIDEO);
                 }
                 else if(type.equals("video"))
                 {
+                    Appodeal.confirm(Appodeal.SKIPPABLE_VIDEO);
                     Appodeal.initialize(activity, appKey, Appodeal.SKIPPABLE_VIDEO);
                 }
                 else if(type.equals("insterstitial"))
@@ -72,6 +74,7 @@ public class GodotAppodeal extends Godot.SingletonBase
                 }
                 else if(type.equals("interstitial/video"))
                 {
+                    Appodeal.confirm(Appodeal.SKIPPABLE_VIDEO);
                     Appodeal.initialize(activity, appKey, Appodeal.INTERSTITIAL | Appodeal.SKIPPABLE_VIDEO);
                 }
                 else if(type.equals("rewardedvideo"))
@@ -186,19 +189,19 @@ public class GodotAppodeal extends Godot.SingletonBase
     public boolean isAnyAdLoaded()
     {
         if (Appodeal.isLoaded(Appodeal.INTERSTITIAL)) {
-			return true;
-		}
-		if (Appodeal.isLoaded(Appodeal.BANNER)) {
-			return true;
-		}
-		if (Appodeal.isLoaded(Appodeal.SKIPPABLE_VIDEO)) {
-			return true;
-		}
-		if (Appodeal.isLoaded(Appodeal.REWARDED_VIDEO)) {
-			return true;
-		}
+		return true;
+	}
+	if (Appodeal.isLoaded(Appodeal.BANNER)) {
+		return true;
+	}
+	if (Appodeal.isLoaded(Appodeal.SKIPPABLE_VIDEO)) {
+		return true;
+	}
+	if (Appodeal.isLoaded(Appodeal.REWARDED_VIDEO)) {
+		return true;
+	}
 		
-		return false;
+	return false;
     }
 
 


### PR DESCRIPTION
Call Appodeal.confirm(Appodeal.SKIPPABLE_VIDEO) to remove appodeal weird popup.

https://www.dropbox.com/s/85qriwhf3l7o3xz/Screenshot_2016-04-30-15-07-11.png?dl=0

Appodeal Instructions:
"Note that it is better to use NON_SKIPPABLE_VIDEO or REWARDED_VIDEO, but if you are sure you want to use SKIPPABLE_VIDEO you must confirm usage by calling Appodeal.confirm(Appodeal.SKIPPABLE_VIDEO) before SDK initialization."
